### PR TITLE
Fixed bug where inputting the same error twice brought up the last fe…

### DIFF
--- a/src/Components/ErrorScreen.js
+++ b/src/Components/ErrorScreen.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import Header from './Header';
-import LocationForm from './LocationForm';
 import SmartLocationListBar from './LocationListBar';
+import { NavLink } from 'react-router-dom'
 
 let ErrorScreen = () =>
   <div className="main">
     <Header />
     <div className='content'>
-      <LocationForm />
+    <NavLink 
+        className='location-link'
+        activeStyle={{fontWeight: 'bold'}}
+        key={Math.Random}
+        to={'/'}> 
+        Home
+      </NavLink>
       <SmartLocationListBar />
       <p className='error-message'>I'm sorry, there was an error getting this locations weather data</p> 
     </div>

--- a/src/Components/FetchForecast.js
+++ b/src/Components/FetchForecast.js
@@ -7,7 +7,7 @@ class FetchForecast extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      weatherResults: {}
+      weatherResults: {},
     }
   }
   fetchData = () => {
@@ -18,8 +18,8 @@ class FetchForecast extends React.Component {
       .then(results => {
         let resultsObject = JSON.parse(results)
         console.log(resultsObject)
-        if (resultsObject.query.count === 0 || !resultsObject.query.results) {
-          this.props.history.push('/error')
+        if (resultsObject.query.count === 0 || resultsObject.query.results === null) {
+          this.props.history.push(`/error/${location}`)
         } else {
           let city = resultsObject.query.results.channel.location.city;
           let state = resultsObject.query.results.channel.location.region;
@@ -49,7 +49,7 @@ class FetchForecast extends React.Component {
   }
 
   render() {
-    if (this.props.weatherResults.item) {
+    if (this.props.weatherResults.item && !this.state.error) {
       return <LocationScreen weatherResults={this.props.weatherResults} />
     } else {
       return <LoadingScreen />

--- a/src/Components/FetchForecast.js
+++ b/src/Components/FetchForecast.js
@@ -19,7 +19,7 @@ class FetchForecast extends React.Component {
         let resultsObject = JSON.parse(results)
         console.log(resultsObject)
         if (resultsObject.query.count === 0 || resultsObject.query.results === null) {
-          this.props.history.push(`/error/${location}`)
+          this.props.history.push('/error')
         } else {
           let city = resultsObject.query.results.channel.location.city;
           let state = resultsObject.query.results.channel.location.region;

--- a/src/router.js
+++ b/src/router.js
@@ -9,7 +9,7 @@ let Router = () =>
     <Switch>
       <Route exact path='/' component={HomeScreen} />
       <Route path='/location/:location' component={FetchForecast}></Route>
-      <Route path='/error/:location' component={ErrorScreen}></Route>
+      <Route path='/error' component={ErrorScreen}></Route>
     </Switch>
   </HashRouter>
 

--- a/src/router.js
+++ b/src/router.js
@@ -9,7 +9,7 @@ let Router = () =>
     <Switch>
       <Route exact path='/' component={HomeScreen} />
       <Route path='/location/:location' component={FetchForecast}></Route>
-      <Route path='/error' component={ErrorScreen}></Route>
+      <Route path='/error/:location' component={ErrorScreen}></Route>
     </Switch>
   </HashRouter>
 


### PR DESCRIPTION
…tched weather data

-Bug 1: typing in two error locations in a row brought up the last fetched weather data.
-Cause: can't navigate to the same location twice using history.push();
-Solution 1: added a parameter to the error route of location.
-Bug 2: same bug, but now only if you type in the exact same error location twice in a row.

Final solution:  remove search input box from error page, replace with a link to the homepage. 